### PR TITLE
Add xslt-version attribute in XSpec files

### DIFF
--- a/src/code-reuse-adaptable-part1/code-reuse-adaptable-part1-avt.xspec
+++ b/src/code-reuse-adaptable-part1/code-reuse-adaptable-part1-avt.xspec
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description
+    stylesheet="code-reuse-adaptable-part1-avt.xsl"
+    xslt-version="3.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://www.w3.org/1999/xhtml"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    xmlns:xv="urn:x-xspectacles:xspec:variables"
-    stylesheet="code-reuse-adaptable-part1-avt.xsl">
+    xmlns:xv="urn:x-xspectacles:xspec:variables">
 
     <!--
         Sample code for "Adaptable Code Reuse in XSpec, Part 1: Value Templates"

--- a/src/code-reuse-adaptable-part1/code-reuse-adaptable-part1.xspec
+++ b/src/code-reuse-adaptable-part1/code-reuse-adaptable-part1.xspec
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description
+    stylesheet="code-reuse-adaptable-part1.xsl"
+    xslt-version="3.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://www.w3.org/1999/xhtml"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    xmlns:xv="urn:x-xspectacles:xspec:variables"
-    stylesheet="code-reuse-adaptable-part1.xsl">
+    xmlns:xv="urn:x-xspectacles:xspec:variables">
 
     <!--
         Sample code for "Adaptable Code Reuse in XSpec, Part 1: Value Templates"

--- a/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2.xspec
+++ b/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2.xspec
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description
+    stylesheet="code-reuse-adaptable-part2.xsl"
+    xslt-version="3.0"
     xmlns:mf="urn:x-xspectacles:functions"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:xv="urn:x-xspectacles:xspec:variables"
-    stylesheet="code-reuse-adaptable-part2.xsl">
+    xmlns:xv="urn:x-xspectacles:xspec:variables">
 
     <!--
         Sample code for "Adaptable Code Reuse in XSpec, Part 2: XPath Matching"

--- a/src/code-reuse/code-reuse-imported.xspec
+++ b/src/code-reuse/code-reuse-imported.xspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description
+    stylesheet="code-reuse.xsl"
+    xslt-version="3.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://www.w3.org/1999/xhtml"
-    xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    stylesheet="code-reuse.xsl">
+    xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
     <!--
         Sample code for "Code Reuse in XSpec: How to Use x:like"

--- a/src/code-reuse/code-reuse-importer.xspec
+++ b/src/code-reuse/code-reuse-importer.xspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description
+    stylesheet="code-reuse.xsl"
+    xslt-version="3.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://www.w3.org/1999/xhtml"
-    xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    stylesheet="code-reuse.xsl">
+    xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
     <!--
         Sample code for "Code Reuse in XSpec: How to Use x:like"

--- a/src/code-reuse/code-reuse-syntax-variations.xspec
+++ b/src/code-reuse/code-reuse-syntax-variations.xspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description
+    stylesheet="code-reuse.xsl"
+    xslt-version="3.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://www.w3.org/1999/xhtml"
-    xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    stylesheet="code-reuse.xsl">
+    xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
     <!--
         Sample code for "Code Reuse in XSpec: How to Use x:like"

--- a/src/code-reuse/code-reuse.xspec
+++ b/src/code-reuse/code-reuse.xspec
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description
+    stylesheet="code-reuse.xsl"
+    xslt-version="3.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="http://www.w3.org/1999/xhtml"
-    xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    stylesheet="code-reuse.xsl">
+    xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
     <!--
         Sample code for "Code Reuse in XSpec: How to Use x:like"

--- a/src/three-dots/three-dots-layered.xspec
+++ b/src/three-dots/three-dots-layered.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="three-dots-layered.xsl"
+    xslt-version="3.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:db="http://docbook.org/ns/docbook"
     xmlns:h="http://www.w3.org/1999/xhtml"

--- a/src/three-dots/three-dots.xspec
+++ b/src/three-dots/three-dots.xspec
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description stylesheet="three-dots.xsl"
+    xslt-version="3.0"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:db="http://docbook.org/ns/docbook"
     xmlns:x="http://www.jenitennison.com/xslt/xspec"


### PR DESCRIPTION
Add `xslt-version` in XSpec tests for XSLT. The value matches `version` attribute in XSLT.

Also, in `x:description`, move namespace declarations after attributes. The sequence is not significant, but I wanted to be consistent across files.