### PR TITLE
Simplify call to string-join

### DIFF
--- a/src/space-preformatted/space-preformatted-module.xqm
+++ b/src/space-preformatted/space-preformatted-module.xqm
@@ -20,7 +20,7 @@ declare function my-xq:li($li as element(li)+) as text() {
         return
         '&#10;* ' || my-xq:li-content($item/node())
     return
-    text { string-join($strings,'') }
+    text { string-join($strings) }
 };
 
 (: For simplicity, use string contents only. :)

--- a/src/space-preformatted/space-preformatted-module.xspec
+++ b/src/space-preformatted/space-preformatted-module.xspec
@@ -26,7 +26,7 @@
             <x:expect label="Result is a sequence of text nodes"
                 test="$x:result instance of text()+"/>
             <x:variable name="xv:actual-as-string" as="xs:string"
-                select="string-join($x:result,'')"/>
+                select="string-join($x:result)"/>
 
             <!-- Solution 1, via separate file. -->
             <x:variable name="xv:file-content-as-string"

--- a/src/space-preformatted/space-preformatted.xspec
+++ b/src/space-preformatted/space-preformatted.xspec
@@ -22,7 +22,7 @@
             <x:expect label="Result is a sequence of text nodes"
                 test="$x:result instance of text()+"/>
             <x:variable name="xv:actual-as-string" as="xs:string"
-                select="string-join($x:result,'')"/>
+                select="string-join($x:result)"/>
 
             <!-- Solution 1, via separate file. -->
             <x:variable name="xv:file-content-as-string"


### PR DESCRIPTION
The one-argument syntax is equivalent to using a zero-length string as the second argument.
