### PR TITLE
Upgrade XSpec from v2.2 to v2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
                     <dependency>
                         <groupId>io.xspec</groupId>
                         <artifactId>xspec</artifactId>
-                        <version>2.2.4</version>
+                        <version>2.3.2</version>
                         <classifier>enduser-files</classifier>
                         <type>zip</type>
                     </dependency>


### PR DESCRIPTION
This pull request upgrades the version of XSpec used in GitHub Actions, now that XSpec v2.3 has been released.