### PR TITLE
Add XQuery sample code to "Adaptable Code Reuse in XSpec, Part 2: XPath Matching"

### DIFF
--- a/src/code-reuse-adaptable-part2/README.md
+++ b/src/code-reuse-adaptable-part2/README.md
@@ -1,7 +1,14 @@
 # Sample code for "Adaptable Code Reuse in XSpec, Part 2: XPath Matching"
 
+Example files for XSLT:
+
 * `code-reuse-adaptable-part2.xsl`
 * `code-reuse-adaptable-part2.xspec`
+
+Example files for XQuery:
+
+* `code-reuse-adaptable-part2-module.xqm`
+* `code-reuse-adaptable-part2-module.xspec`
 
 #### Link to Topic
 [Adaptable Code Reuse in XSpec, Part 2: XPath Matching](https://medium.com/@xspectacles/adaptable-code-reuse-in-xspec-part-2-8820b1cd255d)

--- a/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2-module.xqm
+++ b/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2-module.xqm
@@ -1,0 +1,31 @@
+xquery version "3.1";
+module namespace mf = "urn:x-xspectacles:functions";
+
+declare namespace fn = "http://www.w3.org/2005/xpath-functions";
+declare namespace xs = "http://www.w3.org/2001/XMLSchema";
+
+(:
+    Sample code for "Adaptable Code Reuse in XSpec, Part 2: XPath Matching"
+    https://medium.com/@xspectacles/adaptable-code-reuse-in-xspec-part-2-8820b1cd255d
+:)
+
+declare function mf:options($ignore-dup as xs:boolean) as map(*) {
+    map{
+    'duplicates': ( if ($ignore-dup)
+                    then 'use-last'
+                    else 'reject' ),
+    'escape': false()
+    }
+};
+
+declare function mf:json-processing($json-string as xs:string)
+    as element(fn:map) {
+    <map xmlns="http://www.w3.org/2005/xpath-functions">
+        {(: revision property :)}
+        <string key="revision">1.0</string>
+        {(: properties from $json-string :)}
+        { json-to-xml($json-string)/fn:map/* }
+    </map>
+};
+
+(: Copyright © 2023 by Amanda Galtman. :)

--- a/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2-module.xspec
+++ b/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2-module.xspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description query="urn:x-xspectacles:functions"
+    query-at="code-reuse-adaptable-part2-module.xqm"
+    xmlns:mf="urn:x-xspectacles:functions"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xv="urn:x-xspectacles:xspec:variables">
+
+    <!--
+        Sample code for "Adaptable Code Reuse in XSpec, Part 2: XPath Matching"
+        https://medium.com/@xspectacles/adaptable-code-reuse-in-xspec-part-2-8820b1cd255d
+    -->
+
+    <!--
+        Reuse scenarios from XSpec test for XSLT.
+        The difference between the two files is that this one
+        points to XQuery code in <x:description>, while the
+        imported file points to XSLT code.
+    -->
+    <x:import href="code-reuse-adaptable-part2.xspec"/>
+</x:description>
+
+<!-- Copyright © 2023 by Amanda Galtman. -->

--- a/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2.xspec
+++ b/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2.xspec
@@ -51,6 +51,8 @@
         <x:expect label="Approach 2: Check 'duplicates' value"
             test="$x:result('duplicates')"
             select="$xv:duplicates"/>
+        <x:expect label="Check 'escape' value"
+            test="not($x:result('escape'))"/>
     </x:scenario>
 
     <x:scenario label="Tests for mf:options function">
@@ -78,7 +80,7 @@
         xmlns="http://www.w3.org/2005/xpath-functions">
         <x:scenario label="String values for all properties">
             <x:call function="mf:json-processing">
-                <x:param as="xs:string">
+                <x:param select="/string()">
                     {
                     "year": "1900",
                     "isbn": "978-0470192740"
@@ -95,7 +97,7 @@
         </x:scenario>
         <x:scenario label="Array value for isbn">
             <x:call function="mf:json-processing">
-                <x:param as="xs:string">
+                <x:param select="/string()">
                     {
                     "year": "1900",
                     "isbn": ["0764547763","978-0764547768"]
@@ -140,7 +142,7 @@
         xmlns="http://www.w3.org/2005/xpath-functions">
         <x:scenario label="String values for all properties">
             <x:call function="mf:json-processing">
-                <x:param as="xs:string">
+                <x:param select="/string()">
                     {
                     "year": "1900",
                     "isbn": "978-0470192740"
@@ -154,7 +156,7 @@
         </x:scenario>
         <x:scenario label="Array in isbn">
             <x:call function="mf:json-processing">
-                <x:param as="xs:string">
+                <x:param select="/string()">
                     {
                     "year": "1900",
                     "isbn": ["0764547763","978-0764547768"]
@@ -176,7 +178,7 @@
         <x:scenario label="String values for all properties">
             <x:variable name="xv:isbn-value" select="'978-0470192740'"/>
             <x:call function="mf:json-processing">
-                <x:param as="xs:string" expand-text="1">
+                <x:param expand-text="1" select="/string()">
                     {{
                     "year": "1900",
                     "isbn": "{$xv:isbn-value}"
@@ -192,7 +194,7 @@
             <x:variable name="xv:isbn-value1" select="'0764547763'"/>
             <x:variable name="xv:isbn-value2" select="'978-0764547768'"/>
             <x:call function="mf:json-processing">
-                <x:param as="xs:string" expand-text="1">
+                <x:param expand-text="1" select="/string()">
                     {{
                     "year": "1900",
                     "isbn": ["{$xv:isbn-value1}","{$xv:isbn-value2}"]

--- a/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2.xspec
+++ b/src/code-reuse-adaptable-part2/code-reuse-adaptable-part2.xspec
@@ -51,7 +51,7 @@
         <x:expect label="Approach 2: Check 'duplicates' value"
             test="$x:result('duplicates')"
             select="$xv:duplicates"/>
-        <x:expect label="Check 'escape' value"
+        <x:expect label="Check that 'escape' value is false"
             test="not($x:result('escape'))"/>
     </x:scenario>
 


### PR DESCRIPTION
Follow-up to #4: Add an XQuery function that mimics the XSLT function. The test needed a minor tweak to work in both XQuery and XSLT, because XQuery is stricter than XSLT about data types.