### PR TITLE
Sample code for "One-or-More Ways to Foil Empty-Sequence Surprises in XSpec"

### DIFF
--- a/src/one-or-more/README.md
+++ b/src/one-or-more/README.md
@@ -1,0 +1,21 @@
+# Sample code for "One-or-More Ways to Foil Empty-Sequence Surprises in XSpec"
+
+Example files for XSLT:
+
+* `one-or-more.xsl`
+* `one-or-more-xslt.xspec`
+* `test-document.xml`
+
+Example files for XQuery:
+
+* `one-or-more-module.xqm`
+* `one-or-more-module.xspec`
+* `test-document.xml`
+
+Example files for Schematron:
+
+* `one-or-more.sch`
+* `one-or-more-sch.xspec`
+
+#### Link to Topic
+[One-or-More Ways to Foil Empty-Sequence Surprises in XSpec](https://medium.com/@xspectacles/one-or-more-ways-to-foil-empty-sequence-surprises-in-xspec-882e0af459ea)

--- a/src/one-or-more/one-or-more-module.xqm
+++ b/src/one-or-more/one-or-more-module.xqm
@@ -1,0 +1,32 @@
+xquery version "3.1";
+module namespace mf = "urn:x-xspectacles:functions:one-or-more";
+
+declare namespace xs = "http://www.w3.org/2001/XMLSchema";
+
+(:
+  Sample code for "One-or-More Ways to Foil Empty-Sequence Surprises in XSpec"
+  https://medium.com/@xspectacles/one-or-more-ways-to-foil-empty-sequence-surprises-in-xspec-882e0af459ea
+:)
+
+(: To create deliberate XSpec test problems, <x:expect>
+  uses ul-style instead of style-ul. :)
+declare function mf:create-list() as element() {
+  <div class="container">
+    <div class="style-ul">
+      <ul>
+        <li>div contains list</li>
+        <li>but no p elements</li>
+      </ul>
+    </div>
+  </div>
+};
+
+(: To create deliberate XSpec test failures, <x:param>
+  uses an empty sequence instead of a node. :)
+declare function mf:punct-only-content(
+  $n as node()?
+  ) as xs:string {
+  replace($n/string(),'\P{P}','')
+};
+
+(: Copyright © 2023 by Amanda Galtman. :)

--- a/src/one-or-more/one-or-more-module.xspec
+++ b/src/one-or-more/one-or-more-module.xspec
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description query="urn:x-xspectacles:functions:one-or-more"
+  query-at="one-or-more-module.xqm"
+  xmlns:mf="urn:x-xspectacles:functions:one-or-more"
+  xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!--
+    Sample Code for "One-or-More Ways to Foil Empty-Sequence Surprises in XSpec"
+    https://medium.com/@xspectacles/one-or-more-ways-to-foil-empty-sequence-surprises-in-xspec-882e0af459ea
+  -->
+
+  <!-- Example 1, tests that pass for the wrong reason.
+    "Expecting an Empty Result" -->
+  <x:scenario label="Check for absence of p or text() in div">
+    <x:scenario label="Uncoded assumption that the div exists">
+      <x:call function="mf:create-list"/>
+      <x:expect label="No paragraphs in div"
+        test="$x:result/div[@class='ul-style']/p"
+        select="()"/>
+      <x:expect label="No paragraphs in div"
+        test="empty($x:result/div[@class='ul-style']/p)"/>
+      <x:expect label="No bare text in div"
+        test="$x:result/div[@class='ul-style']/text()"
+        select="()"/>
+      <x:expect label="No bare text in div"
+        test="empty($x:result/div[@class='ul-style']/text())"/>
+    </x:scenario>
+
+    <x:scenario label="Checking that the div exists, or else test failure"
+      pending="First x:expect fails">
+      <x:call function="mf:create-list"/>
+      <!-- If first x:expect fails, the subsequent ones pass
+        for the wrong reason. -->
+      <x:expect label="div exists"
+        test="exists($x:result/div[@class='ul-style'])"/>
+
+      <x:expect label="No paragraphs in div"
+        test="$x:result/div[@class='ul-style']/p"
+        select="()"/>
+      <x:expect label="No paragraphs in div"
+        test="empty($x:result/div[@class='ul-style']/p)"/>
+      <x:expect label="No bare text in div"
+        test="$x:result/div[@class='ul-style']/text()"
+        select="()"/>
+      <x:expect label="No bare text in div"
+        test="empty($x:result/div[@class='ul-style']/text())"/>
+    </x:scenario>
+
+    <x:scenario label="Checking that the div exists, or else error"
+      pending="Each x:expect issues error message">
+      <x:call function="mf:create-list"/>
+      <x:expect label="No paragraphs in div"
+        test="one-or-more($x:result/div[@class='ul-style'])/p"
+        select="()"/>
+      <x:expect label="No paragraphs in div"
+        test="empty(
+          one-or-more($x:result/div[@class='ul-style'])/p
+        )"/>
+      <x:expect label="No bare text in div"
+        test="one-or-more($x:result/div[@class='ul-style'])/text()"
+        select="()"/>
+      <x:expect label="No bare text in div"
+        test="empty(
+          one-or-more($x:result/div[@class='ul-style'])/text()
+        )"/>
+    </x:scenario>
+
+    <x:scenario label="Checking that the div exists, or else error"
+      pending="Each x:expect issues error message">
+      <x:call function="mf:create-list"/>
+      <x:expect label="No paragraphs in div"
+        test="($x:result/div[@class='ul-style'] treat as element()+)/p"
+        select="()"/>
+      <x:expect label="No paragraphs in div"
+        test="empty(
+        ($x:result/div[@class='ul-style'] treat as element()+)/p
+        )"/>
+      <x:expect label="No bare text in div"
+        test="($x:result/div[@class='ul-style'] treat as element()+)/text()"
+        select="()"/>
+      <x:expect label="No bare text in div"
+        test="empty(
+        ($x:result/div[@class='ul-style'] treat as element()+)/text()
+        )"/>
+    </x:scenario>
+  </x:scenario>
+
+  <!-- Example 2, showing confusing failures.
+    "Similar Problem, with x:param" -->
+  <x:scenario label="Check that regexp is correct">
+    <x:scenario label="Mistake: x:param/@select does not select anything"
+      pending="x:expect fails">
+      <x:call function="mf:punct-only-content">
+        <x:param href="test-document.xml"
+          select="p[1]"/>
+      </x:call>
+      <x:expect label="Punctuation characters from paragraph"
+        select="':-)'"/>
+    </x:scenario>
+    <x:scenario label="Checking that the node exists, or else error from exactly-one"
+      pending="x:param issues error message">
+      <x:call function="mf:punct-only-content">
+        <x:param href="test-document.xml"
+          select="exactly-one(p[1])"/>
+      </x:call>
+      <x:expect label="Punctuation characters from paragraph"
+        select="':-)'"/>
+    </x:scenario>
+    <x:scenario label="Checking that the node exists, or else error from 'as'"
+      pending="x:param issues error message">
+      <x:call function="mf:punct-only-content">
+        <x:param href="test-document.xml"
+          as="element()"
+          select="p[1]"/>
+      </x:call>
+      <x:expect label="Punctuation characters from paragraph"
+        select="':-)'"/>
+    </x:scenario>
+  </x:scenario>
+</x:description>
+
+<!-- Copyright © 2023 by Amanda Galtman. -->

--- a/src/one-or-more/one-or-more-sch.xspec
+++ b/src/one-or-more/one-or-more-sch.xspec
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description schematron="one-or-more.sch"
+  xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+  <!--
+    Sample Code for "One-or-More Ways to Foil Empty-Sequence Surprises in XSpec"
+    https://medium.com/@xspectacles/one-or-more-ways-to-foil-empty-sequence-surprises-in-xspec-882e0af459ea
+  -->
+
+  <x:scenario label="Schematron does not fire any rules (FAIL)" pending="fails">
+    <x:context select="/article/section[2]">
+      <article>
+        <section>
+          <title>Title</title>
+        </section>
+      </article>
+    </x:context>
+    <x:expect-not-assert label="FAIL"/>
+    <x:expect-assert label="FAIL"/>
+    <x:expect-valid/><!-- FAIL -->
+  </x:scenario>
+  
+  <x:scenario label="Schematron fires rule but does not throw assert (@location is irrelevant)">
+    <x:context>
+      <article>
+        <section>
+          <title>Title</title>
+        </section>
+      </article>
+    </x:context>
+    <x:expect-not-assert label="PASS" location="/article/section[2]"/>
+    <x:expect-not-assert label="PASS" location="exactly-one(/article/section[2])"/>
+    <x:expect-assert label="FAIL" location="/article/section[2]" pending="fails"/>
+    <x:expect-assert label="FAIL" location="exactly-one(/article/section[2])" pending="fails"/>
+  </x:scenario>
+
+  <x:scenario label="Schematron throws assert" pending="errors">
+    <x:context>
+      <article>
+        <section/>
+      </article>
+    </x:context>
+    <x:expect-not-assert label="ERROR" location="/article/section[2]"/>
+    <x:expect-assert label="ERROR" location="/article/section[2]"/>
+  </x:scenario>
+</x:description>
+
+<!-- Copyright © 2023 by Amanda Galtman. -->

--- a/src/one-or-more/one-or-more-xslt.xspec
+++ b/src/one-or-more/one-or-more-xslt.xspec
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description stylesheet="one-or-more.xsl"
+  xmlns:mf="urn:x-xspectacles:functions:one-or-more"
+  xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!--
+    Sample Code for "One-or-More Ways to Foil Empty-Sequence Surprises in XSpec"
+    https://medium.com/@xspectacles/one-or-more-ways-to-foil-empty-sequence-surprises-in-xspec-882e0af459ea
+  -->
+
+  <!-- Example 1, tests that pass for the wrong reason.
+      "Expecting an Empty Result" -->
+  <x:scenario label="Check for absence of p or text() in div">
+    <x:scenario label="Uncoded assumption that the div exists">
+      <x:call function="mf:create-list"/>
+      <x:expect label="No paragraphs in div"
+        test="$x:result/div[@class='ul-style']/p" select="()"/>
+      <x:expect label="No paragraphs in div"
+        test="empty($x:result/div[@class='ul-style']/p)"/>
+      <x:expect label="No bare text in div"
+        test="$x:result/div[@class='ul-style']/text()" select="()"/>
+      <x:expect label="No bare text in div"
+        test="empty($x:result/div[@class='ul-style']/text())"/>
+    </x:scenario>
+
+    <x:scenario label="Checking that the div exists, or else test failure"
+      pending="First x:expect fails">
+      <x:call function="mf:create-list"/>
+      <!-- If first x:expect fails, the subsequent ones pass
+        for the wrong reason. -->
+      <x:expect label="div exists"
+        test="exists($x:result/div[@class='ul-style'])"/>
+
+      <x:expect label="No paragraphs in div"
+        test="$x:result/div[@class='ul-style']/p" select="()"/>
+      <x:expect label="No paragraphs in div"
+        test="empty($x:result/div[@class='ul-style']/p)"/>
+      <x:expect label="No bare text in div"
+        test="$x:result/div[@class='ul-style']/text()" select="()"/>
+      <x:expect label="No bare text in div"
+        test="empty($x:result/div[@class='ul-style']/text())"/>
+    </x:scenario>
+
+    <x:scenario label="Checking that the div exists, or else error"
+      pending="Each x:expect issues error message">
+      <x:call function="mf:create-list"/>
+      <x:expect label="No paragraphs in div"
+        test="one-or-more($x:result/div[@class='ul-style'])/p" select="()"/>
+      <x:expect label="No paragraphs in div" test="empty(
+                one-or-more($x:result/div[@class='ul-style'])/p
+                )"/>
+      <x:expect label="No bare text in div"
+        test="one-or-more($x:result/div[@class='ul-style'])/text()" select="()"/>
+      <x:expect label="No bare text in div" test="empty(
+                one-or-more($x:result/div[@class='ul-style'])/text()
+                )"/>
+    </x:scenario>
+
+    <x:scenario label="Checking that the div exists, or else error"
+      pending="Each x:expect issues error message">
+      <x:call function="mf:create-list"/>
+      <x:expect label="No paragraphs in div"
+        test="($x:result/div[@class='ul-style'] treat as element()+)/p"
+        select="()"/>
+      <x:expect label="No paragraphs in div" test="empty(
+                ($x:result/div[@class='ul-style'] treat as element()+)/p
+                )"/>
+      <x:expect label="No bare text in div"
+        test="($x:result/div[@class='ul-style'] treat as element()+)/text()"
+        select="()"/>
+      <x:expect label="No bare text in div" test="empty(
+                ($x:result/div[@class='ul-style'] treat as element()+)/text()
+                )"/>
+    </x:scenario>
+  </x:scenario>
+
+  <!-- Example 2, showing confusing failures.
+    "Similar Problem, with x:param" -->
+  <x:scenario label="Check that regexp is correct">
+    <x:scenario label="Mistake: x:param/@select does not select anything"
+      pending="x:expect fails">
+      <x:call function="mf:punct-only-content">
+        <x:param href="test-document.xml" select="p[1]"/>
+      </x:call>
+      <x:expect label="Punctuation characters from paragraph" select="':-)'"/>
+    </x:scenario>
+    <x:scenario
+      label="Checking that the node exists, or else error from exactly-one"
+      pending="x:param issues error message">
+      <x:call function="mf:punct-only-content">
+        <x:param href="test-document.xml" select="exactly-one(p[1])"/>
+      </x:call>
+      <x:expect label="Punctuation characters from paragraph" select="':-)'"/>
+    </x:scenario>
+    <x:scenario label="Checking that the node exists, or else error from 'as'"
+      pending="x:param issues error message">
+      <x:call function="mf:punct-only-content">
+        <x:param href="test-document.xml" as="element()" select="p[1]"/>
+      </x:call>
+      <x:expect label="Punctuation characters from paragraph" select="':-)'"/>
+    </x:scenario>
+  </x:scenario>
+</x:description>
+
+<!-- Copyright © 2023 by Amanda Galtman. -->

--- a/src/one-or-more/one-or-more.sch
+++ b/src/one-or-more/one-or-more.sch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
+  xmlns:sqf="http://www.schematron-quickfix.com/validator/process">
+
+  <!--
+    Sample Code for "One-or-More Ways to Foil Empty-Sequence Surprises in XSpec"
+    https://medium.com/@xspectacles/one-or-more-ways-to-foil-empty-sequence-surprises-in-xspec-882e0af459ea
+  -->
+
+  <sch:pattern>
+    <sch:rule context="section">
+      <sch:assert test="title">Section must have a title</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+</sch:schema>
+
+<!-- Copyright © 2023 by Amanda Galtman. -->

--- a/src/one-or-more/one-or-more.xsl
+++ b/src/one-or-more/one-or-more.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet
+  xmlns:mf="urn:x-xspectacles:functions:one-or-more"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  exclude-result-prefixes="#all"
+  version="3.0">
+
+  <!--
+    Sample Code for "One-or-More Ways to Foil Empty-Sequence Surprises in XSpec"
+    https://medium.com/@xspectacles/one-or-more-ways-to-foil-empty-sequence-surprises-in-xspec-882e0af459ea
+  -->
+
+  <!-- To create deliberate XSpec test problems, <x:expect>
+    uses ul-style instead of style-ul. -->
+  <xsl:function name="mf:create-list" as="element()">
+    <div class="container">
+      <div class="style-ul">
+        <ul>
+          <li>div contains list</li>
+          <li>but no p elements</li>
+        </ul>
+      </div>
+    </div>
+  </xsl:function>
+
+  <!-- To create deliberate XSpec test failures, <x:param>
+    uses an empty sequence instead of a node. -->
+  <xsl:function name="mf:punct-only-content" as="xs:string">
+    <xsl:param name="n" as="node()?"/>
+    <xsl:sequence select="replace($n/string(),'\P{P}','')"/>
+  </xsl:function>
+
+</xsl:stylesheet>
+
+<!-- Copyright © 2023 by Amanda Galtman. -->

--- a/src/one-or-more/test-document.xml
+++ b/src/one-or-more/test-document.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<div>
+  <p>a:b-c)d</p>
+</div>


### PR DESCRIPTION
Corresponds to [One-or-More Ways to Foil Empty-Sequence Surprises in XSpec](https://medium.com/@xspectacles/one-or-more-ways-to-foil-empty-sequence-surprises-in-xspec-882e0af459ea)