### PR TITLE
Bump xspec-maven-plugin from 2.0.0 to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>com.nkutsche</groupId>
                 <artifactId>xspec-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
                         <id>run-xspec</id>


### PR DESCRIPTION
This pull request updates the Maven test runner to get the fix for https://github.com/nkutsche/xspec-maven-plugin/issues/7