### PR TITLE
Upgrade XSpec from v2.3 to v3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
                     <dependency>
                         <groupId>io.xspec</groupId>
                         <artifactId>xspec</artifactId>
-                        <version>2.3.2</version>
+                        <version>3.0.3</version>
                         <classifier>enduser-files</classifier>
                         <type>zip</type>
                     </dependency>

--- a/src/schematron-messages/schematron-messages-with-diag.xspec
+++ b/src/schematron-messages/schematron-messages-with-diag.xspec
@@ -21,7 +21,7 @@
       Move children to "Top-Level Section" info.
     </x:expect-assert>
     <x:expect-assert label="Check diagnostic:"
-      id="subsection-no-info">[WG 1.2] q</x:expect-assert>
+      id="subsection-no-info">[WG 1.2]</x:expect-assert>
   </x:scenario>
 
 </x:description>


### PR DESCRIPTION
This PR updates the XSpec version used to run tests in this repo, from v2.3.2 to v3.0.3.