### PR TITLE
Upgrade XSpec from v3.0 to v3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
                     <dependency>
                         <groupId>io.xspec</groupId>
                         <artifactId>xspec</artifactId>
-                        <version>3.0.3</version>
+                        <version>3.1.2</version>
                         <classifier>enduser-files</classifier>
                         <type>zip</type>
                     </dependency>


### PR DESCRIPTION
This PR updates the XSpec version used to run tests in this repo, from v3.0.3 to v3.1.2.