### PR TITLE
Tweak code for Part 2 of "Ignoring Code Comments During XSpec Testing"

### DIFF
--- a/src/helper-comments/README.md
+++ b/src/helper-comments/README.md
@@ -13,5 +13,7 @@ Example files for XQuery:
 - `helper-remove-comments-xq.xspec`
 
 
-#### Link to Topic
-[Ignoring Code Comments During XSpec Testing](https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-a460f35a25bb)
+#### Links to Topics
+
+- [Ignoring Code Comments During XSpec Testing, Part 1](https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-a460f35a25bb)
+- [Ignoring Code Comments During XSpec Testing, Part 2](https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-part-2-8266ee8ceccc)

--- a/src/helper-comments/helper-remove-comments-xq.xspec
+++ b/src/helper-comments/helper-remove-comments-xq.xspec
@@ -5,8 +5,8 @@
   xmlns:x="http://www.jenitennison.com/xslt/xspec">
 
   <!--
-    Sample Code for "Ignoring Code Comments During XSpec Testing"
-    https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-a460f35a25bb
+    Sample Code for "Ignoring Code Comments During XSpec Testing, Part 2"
+    https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-part-2-8266ee8ceccc
   -->
 
   <x:helper query="urn:x-xspectacles:functions:helper:remove-comments"

--- a/src/helper-comments/helper-remove-comments.xqm
+++ b/src/helper-comments/helper-remove-comments.xqm
@@ -1,20 +1,21 @@
-xquery version "3.1";
+xquery version "1.0";
 module namespace frc = "urn:x-xspectacles:functions:helper:remove-comments";
 
 (:
-  Sample Code for "Ignoring Code Comments During XSpec Testing"
-  https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-a460f35a25bb
+  Sample Code for "Ignoring Code Comments During XSpec Testing, Part 2"
+  https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-part-2-8266ee8ceccc
 :)
 
 declare variable $frc:prefix as xs:string := 'TEST NOTE:';
+
 (:
-Removes certain comments from $node, assumed to be an element,
+Remove certain comments from $node, assumed to be an element,
 document node, or empty sequence. The comments to remove are those
 whose space-normalized content starts with 'TEST NOTE:'.
 :)
-declare %public function frc:remove-comments(
+declare function frc:remove-comments(
 $node as node()?
-) {
+) as node()? {
   typeswitch ($node)
     case comment()
       return
@@ -30,7 +31,30 @@ $node as node()?
         $node
 };
 
-declare %private function frc:element-handler(
+(: Discard comment nodes that start with specified prefix. :)
+declare function frc:comment-handler(
+$node as comment()
+) as comment()? {
+  if (starts-with(normalize-space($node), $frc:prefix))
+  then
+    ()
+  else
+    $node
+};
+
+(: Create document node and process children. :)
+declare function frc:doc-node-handler(
+$node as document-node()
+) as document-node() {
+  document {
+    for $child in $node/node()
+    return
+      frc:remove-comments($child)
+  }
+};
+
+(: Create element wrapper and process children. :)
+declare function frc:element-handler(
 $node as element()
 ) as element() {
   element {node-name($node)} {
@@ -42,26 +66,6 @@ $node as element()
     return
       frc:remove-comments($child)
   }
-};
-
-declare %private function frc:doc-node-handler(
-$node as document-node()
-) as document-node() {
-  document {
-    for $child in $node/node()
-    return
-      frc:remove-comments($child)
-  }
-};
-
-declare %private function frc:comment-handler(
-$node as comment()
-) as comment()? {
-  if (starts-with(normalize-space($node), $frc:prefix))
-  then
-    ()
-  else
-    $node
 };
 
 (: Copyright © 2024 by Amanda Galtman. :)

--- a/src/helper-comments/helper-remove-comments.xsl
+++ b/src/helper-comments/helper-remove-comments.xsl
@@ -11,12 +11,13 @@
   -->
 
   <!--
-    Removes certain comments from $node, assumed to be an element,
+    Remove certain comments from $node, assumed to be an element,
     document node, or empty sequence. The comments to remove are those
     whose space-normalized content starts with 'TEST NOTE:'.
   -->
-  <xsl:function name="frc:remove-comments" as="node()" visibility="public">
-    <xsl:param name="element-or-document-node" as="node()"/>
+  <xsl:function name="frc:remove-comments" as="node()?"
+    visibility="public">
+    <xsl:param name="element-or-document-node" as="node()?"/>
     <xsl:apply-templates select="$element-or-document-node"
       mode="mrc:remove-comments"/>
   </xsl:function>

--- a/src/helper-comments/test-target.xqm
+++ b/src/helper-comments/test-target.xqm
@@ -1,9 +1,9 @@
-xquery version "3.1";
+xquery version "1.0";
 module namespace rpt = "urn:x-xspectacles:functions:report";
 
 (:
-  Sample Code for "Ignoring Code Comments During XSpec Testing"
-  https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-a460f35a25bb
+  Sample Code for "Ignoring Code Comments During XSpec Testing, Part 2"
+  https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-part-2-8266ee8ceccc
 :)
 
 declare function rpt:report(


### PR DESCRIPTION
Corresponds to [Ignoring Code Comments During XSpec Testing, Part 2](https://medium.com/@xspectacles/ignoring-code-comments-during-xspec-testing-part-2-8266ee8ceccc)

This code was part of #50, and this pull request makes some minor updates.