### PR TITLE
Sample code for "Overriding Global XSLT Variables in XSpec, Part 1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each post corresponds to a [subfolder under `src/`](https://github.com/galtm/xsp
 * [Multiple Cases in One XSpec Scenario](https://github.com/galtm/xspectacles/tree/main/src/context-sequence)
 * [My XML Content in XSpec Causes an Error](https://github.com/galtm/xspectacles/tree/main/src/xml-content-error)
 * [One-or-More Ways to Foil Empty-Sequence Surprises in XSpec](https://github.com/galtm/xspectacles/tree/main/src/one-or-more)
+* **(NEW!)** [Overriding Global XSLT Variables in XSpec, Part 1](https://github.com/galtm/xspectacles/tree/main/src/override-global-var-part1)
 * [Saying "Almost Valid" or "Beyond Valid" in XSpec Tests for Schematron](https://github.com/galtm/xspectacles/tree/main/src/almost-valid)
 * [Saying "Not Yet" in XSpec](https://github.com/galtm/xspectacles/tree/main/src/pending)
 * [Saying "Whatever" in XSpec: How, Why, When](https://github.com/galtm/xspectacles/tree/main/src/three-dots)
@@ -38,4 +39,4 @@ Each post corresponds to a [subfolder under `src/`](https://github.com/galtm/xsp
 * [The Equality Check that's Neither True Nor False](https://github.com/galtm/xspectacles/tree/main/src/non-boolean-eq)
 * [Ways to Access XSLT Result in XSpec Testing: Dot Versus Result Variable](https://github.com/galtm/xspectacles/tree/main/src/dot-versus-result)
 * [XQuery Makeover to Improve Testability with XSpec](https://github.com/galtm/xspectacles/tree/main/src/xquery-modules)
-* **(NEW!)** [XQuery Update Facility Can Simplify XSpec Test Helper Functions](https://github.com/galtm/xspectacles/tree/main/src/helper-comments-xquf)
+* [XQuery Update Facility Can Simplify XSpec Test Helper Functions](https://github.com/galtm/xspectacles/tree/main/src/helper-comments-xquf)

--- a/src/override-global-var-part1/README.md
+++ b/src/override-global-var-part1/README.md
@@ -1,0 +1,15 @@
+# Sample code for "Overriding Global XSLT Variables in XSpec, Part 1"
+
+Example files for `run-as="import"` (default):
+
+- `test-target.xsl`
+- `override-global-var.xspec`
+
+Example files for `run-as="external"`:
+
+- `test-target-for-external.xsl`
+- `external_cannot-override-global-var.xspec`
+- `external_override-global-param.xspec`
+
+#### Links to Topic
+[Overriding Global XSLT Variables in XSpec, Part 1](https://medium.com/@xspectacles/overriding-global-xslt-variables-in-xspec-part1-d5c00bd1550d)

--- a/src/override-global-var-part1/external_cannot-override-global-var.xspec
+++ b/src/override-global-var-part1/external_cannot-override-global-var.xspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<x:description run-as="external" stylesheet="test-target.xsl"
+  xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+  <!--
+    Sample Code for "Overriding Global XSLT Variables in XSpec, Part 1"
+    https://medium.com/@xspectacles/overriding-global-xslt-variables-in-xspec-part1-d5c00bd1550d
+  -->
+
+  <x:param name="my-param" select="'from x:param'"/>
+  <x:param name="data-file-name" select="'test-data1.xml'"/>
+
+  <x:scenario label="With global x:param, template uses">
+    <x:call template="show-values-of-globals"/>
+    <x:expect label="the XSLT value of xsl:variable"
+      select="('from x:param', 'production.xml')"/>
+  </x:scenario>
+
+</x:description>
+<!-- Copyright © 2024 by Amanda Galtman. -->

--- a/src/override-global-var-part1/external_override-global-param.xspec
+++ b/src/override-global-var-part1/external_override-global-param.xspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<x:description run-as="external"
+  stylesheet="test-target-for-external.xsl"
+  xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+  <!--
+    Sample Code for "Overriding Global XSLT Variables in XSpec, Part 1"
+    https://medium.com/@xspectacles/overriding-global-xslt-variables-in-xspec-part1-d5c00bd1550d
+  -->
+
+  <x:scenario label="Replace xsl:variable with xsl:param in XSLT">
+    <x:scenario label="With x:param, template uses">
+      <x:param name="my-param" select="'from x:param'"/>
+      <x:param name="data-file-name" select="'test-data1.xml'"/>
+      <x:call template="show-values-of-globals"/>
+      <x:expect label="the provided values"
+        select="('from x:param', 'test-data1.xml')"/>
+    </x:scenario>
+    <x:scenario label="Without x:param, template uses">
+      <x:call template="show-values-of-globals"/>
+      <x:expect label="default values from XSLT"
+        select="('from production', 'production.xml')"/>
+    </x:scenario>
+  </x:scenario>
+</x:description>
+<!-- Copyright © 2024 by Amanda Galtman. -->

--- a/src/override-global-var-part1/override-global-var.xspec
+++ b/src/override-global-var-part1/override-global-var.xspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<x:description run-as="import" stylesheet="test-target.xsl"
+  xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+  <!--
+    Sample Code for "Overriding Global XSLT Variables in XSpec, Part 1"
+    https://medium.com/@xspectacles/overriding-global-xslt-variables-in-xspec-part1-d5c00bd1550d
+  -->
+
+  <x:param name="my-param" select="'from x:param'"/>
+  <x:param name="data-file-name" select="'test-data1.xml'"/>
+
+  <x:scenario label="With global x:param, template uses">
+    <x:call template="show-values-of-globals"/>
+    <x:expect label="the provided values"
+      select="('from x:param', 'test-data1.xml')"/>
+  </x:scenario>
+</x:description>
+<!-- Copyright © 2024 by Amanda Galtman. -->

--- a/src/override-global-var-part1/test-target-for-external.xsl
+++ b/src/override-global-var-part1/test-target-for-external.xsl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <!--
+    Sample Code for "Overriding Global XSLT Variables in XSpec, Part 1"
+    https://medium.com/@xspectacles/overriding-global-xslt-variables-in-xspec-part1-d5c00bd1550d
+  -->
+
+  <xsl:param name="my-param" as="xs:string"
+    select="'from production'"/>
+  <xsl:param name="data-file-name" as="xs:string"
+    select="'production.xml'"/>
+
+  <xsl:template name="show-values-of-globals" as="xs:string+">
+    <xsl:sequence select="($my-param, $data-file-name)"/>
+  </xsl:template>
+
+</xsl:stylesheet>
+<!-- Copyright © 2024 by Amanda Galtman. -->

--- a/src/override-global-var-part1/test-target.xsl
+++ b/src/override-global-var-part1/test-target.xsl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <!--
+    Sample Code for "Overriding Global XSLT Variables in XSpec, Part 1"
+    https://medium.com/@xspectacles/overriding-global-xslt-variables-in-xspec-part1-d5c00bd1550d
+  -->
+
+  <xsl:param name="my-param" as="xs:string"
+    select="'from production'"/>
+  <xsl:variable name="data-file-name" as="xs:string"
+    select="'production.xml'"/>
+
+  <xsl:template name="show-values-of-globals" as="xs:string+">
+    <xsl:sequence select="($my-param, $data-file-name)"/>
+  </xsl:template>
+
+</xsl:stylesheet>
+<!-- Copyright © 2024 by Amanda Galtman. -->


### PR DESCRIPTION
Corresponds to [Overriding Global XSLT Variables in XSpec, Part 1](https://medium.com/@xspectacles/overriding-global-xslt-variables-in-xspec-part1-d5c00bd1550d)