### PR TITLE
More Schematron verifications in result-type example

### DIFF
--- a/src/result-type/result-type-sch.xspec
+++ b/src/result-type/result-type-sch.xspec
@@ -28,6 +28,11 @@
       </x:context>
       <!-- Unexpected error occurs -->
       <x:expect-not-assert id="unknown-type" label="(FAILS)"/>
+      <x:expect-assert count="0" label="(FAILS)"/>
+      <x:expect-not-report label="(FAILS)"/>
+      <x:expect-report count="0" label="(FAILS)"/>
+      <x:expect-rule context="/*" label="(FAILS)"/>
+      <x:expect-valid/><!-- FAILS -->
     </x:scenario>
   </x:scenario>
 


### PR DESCRIPTION
For the Schematron example file related to the "Pre-Checking the Result Type in XSpec" topic, make the unexpected-error scenario include all the Schematron-specific verification elements.

- Running the test under XSpec without the `result-type` feature leads to a non-user-friendly fatal error (see https://github.com/xspec/xspec/pull/2122#issuecomment-2906783415) for the first of those verification elements. The remaining verification elements don't execute due to the error on the first one.
- Running the test under XSpec with the `result-type` feature causes all these verifications to fail, and there is no fatal error.
