### PR TITLE
maven: set ignoreFocus to false in plug-in v2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
                         <exclude>helper-comments-xquf/helper-remove-comments-xquf.xspec</exclude>
                     </excludes>
                     <catalogFile>${project.basedir}/src/pointing-by-catalog/data/DATA-CATALOG.xml</catalogFile>
+                    <ignoreFocus>false</ignoreFocus>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
At least one XSpec file in this repository (`pending/pending-xslt.xspec`) uses the `focus` attribute to illustrate its usage. Therefore, the Maven plug-in should not ignore `focus`.
