### PR TITLE
Declare xs namespace prefix where needed

### DIFF
--- a/src/relaxng/relaxng-test.xspec
+++ b/src/relaxng/relaxng-test.xspec
@@ -2,6 +2,7 @@
 <x:description
   xmlns:validate="http://basex.org/modules/validate"
   xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xv="urn:x-xspectacles:xspec:variables"
   query="urn:x-xspectacles:functions:noop"
   query-at="no-op.xqm">


### PR DESCRIPTION
A certain test for an XQuery module is missing the namespace declaration for the `xs` prefix. The test runs fine now because the XQuery processor always knows what this standard prefix means. However, the change in https://github.com/xspec/xspec/pull/2103 for XSpec v3.3 causes the XSLT-based XSpec compiler to need the namespace declaration, too. The declaration should have been in the `.xspec` file all along, so this PR adds it.